### PR TITLE
本番環境にトップページが映らなくなった問題の修正

### DIFF
--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -2,7 +2,7 @@
   =render 'shared/top-header'
 
 .header-img
-  = image_tag "index_01"
+  = image_tag "index_01.png"
 
 .main-content
   .pickup-container


### PR DESCRIPTION
# What
image_tagの名前に.pngを追加
# Why
トップページの画像の表示を修正するために記述変更したところ、デプロイ後ページそのものが映らなくなったため、記述箇所のミスを修正