### PR TITLE
userテーブルからresidence_idカラムの削除

### DIFF
--- a/db/migrate/20191109055106_change_column_to_user.rb
+++ b/db/migrate/20191109055106_change_column_to_user.rb
@@ -1,0 +1,7 @@
+class ChangeColumnToUser < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :users, :residences
+    remove_index :users, :residence_id
+    remove_reference :users, :residence
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_07_134315) do
+ActiveRecord::Schema.define(version: 2019_11_09_055106) do
 
   create_table "blands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -102,11 +102,9 @@ ActiveRecord::Schema.define(version: 2019_11_07_134315) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "residence_id"
     t.text "introduction"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["residence_id"], name: "index_users_on_residence_id"
   end
 
   add_foreign_key "comments", "items"
@@ -117,5 +115,4 @@ ActiveRecord::Schema.define(version: 2019_11_07_134315) do
   add_foreign_key "items", "categories"
   add_foreign_key "items", "users"
   add_foreign_key "residences", "users"
-  add_foreign_key "users", "residences"
 end


### PR DESCRIPTION
# what
外部キー制約をかけたresidence_idカラムがあったが不要であったため削除

# why
このカラムがあることによるエラーが起きてしまったため