### PR TITLE
sns_credentialモデルにバリデーション追加

### DIFF
--- a/app/models/sns_credential.rb
+++ b/app/models/sns_credential.rb
@@ -1,3 +1,8 @@
 class SnsCredential < ApplicationRecord
   belongs_to :user, optional: true
+
+  #snscredentialモデル validation
+  validates :uid, presence: true
+  validates :provider, presence: true
+  validates :user_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,14 +10,14 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :residence 
   has_many :sns_credentials, dependent: :destroy
   
-#varidation
+#varidation format
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   VALID_PHONE_REGEX = /\A\d{10}$|^\d{11}\z/
   VALID_KATAKANA_REGEX = /\A[\p{katakana}\p{blank}ー－]+\z/
   VALID_PASSWORD_REGEX = /\A(?=.*?[a-zA-Z])(?=.*?\d)[a-zA-Z\d]{7,128}+\z/i
  
 
-# user
+# userモデル validation
 #   nickname 空ではないか、最大20文字、一意制約
   validates :nickname, presence: true, uniqueness: true, length: { maximum: 20 }
 #   email 空ではないか、適切なフォーマットであるか、一意制約

--- a/spec/factories/sns_credentials.rb
+++ b/spec/factories/sns_credentials.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+
+  factory :sns_credential do
+      uid      { "12345678" }
+      provider { "google_oauth2" }
+      user_id  { 1 }
+  end
+
+end

--- a/spec/models/sns_credential_spec.rb
+++ b/spec/models/sns_credential_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe SnsCredential, type: :model do
+  describe '#create' do
+
+    before do
+      user = create(:user, id: 1)
+    end
+
+    #uid,provider,user_idがあれば登録できる
+    it "is valid with a column" do
+      sns = build(:sns_credential)
+      expect(sns).to be_valid
+    end
+
+    #uidが空では登録できない
+    it "is invalid without a uid" do
+      sns = build(:sns_credential, uid: nil)
+      sns.valid?
+      expect(sns.errors[:uid]).to include("を入力してください")
+    end
+
+    #providerが空では登録できない
+    it "is invalid without a provider" do
+      sns = build(:sns_credential, provider: nil)
+      sns.valid?
+      expect(sns.errors[:provider]).to include("を入力してください")
+    end
+
+    #user_idが空では登録できない
+    it "is invalid without a user_id" do
+      sns = build(:sns_credential, user_id: nil)
+      sns.valid?
+      expect(sns.errors[:user_id]).to include("を入力してください")
+    end
+
+  end
+end


### PR DESCRIPTION
# what
sns_credentialモデルにバリデーション追加
sns_credentialモデルの単体テストを行う

# why
異常な値が入らないようにするため