### PR TITLE
hotfix-本人情報確認ページの修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,4 +27,5 @@
 @import "km-log_in/km-login";
 @import "module/tn-credit_cards-new";
 @import "module/tn-credit_cards-show";
-@import "./search"
+@import "./search";
+@import "km-modules/km-error-flash";

--- a/app/assets/stylesheets/km-modules/km-error-flash.scss
+++ b/app/assets/stylesheets/km-modules/km-error-flash.scss
@@ -1,0 +1,6 @@
+.km-error-container {
+  background-color: red;
+  color: white;
+  font-weight: bold;
+  text-align: center;
+}

--- a/app/assets/stylesheets/module/_tn-users-edit.scss
+++ b/app/assets/stylesheets/module/_tn-users-edit.scss
@@ -64,6 +64,7 @@
         text-align: center;
         line-height: 40px;
         color: white;
+        cursor: pointer;
       }
     }
   }

--- a/app/controllers/residences_controller.rb
+++ b/app/controllers/residences_controller.rb
@@ -6,12 +6,14 @@ class ResidencesController < ApplicationController
 
   def update
     residence = Residence.find(params[:id])
-    if residence.user_id == current_user.id
-      residence.update(residence_params)
-      redirect_to user_path
-    else
-      render :edit
-    end
+    residence.update(residence_params)
+    redirect_to "/users/#{current_user.id}"
+    # if residence.user_id == current_user.id
+    #   residence.update(residence_params)
+    #   redirect_to user_path
+    # else
+    #   render :edit
+    # end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 class UsersController < ApplicationController
+  before_action :set_residence, only: [:show, :edit, :logout]
 
   def show
+    redirect_to root_path unless @residence
   end
   
   def edit
@@ -8,7 +10,7 @@ class UsersController < ApplicationController
 
   def update
     if current_user.update(user_params)
-      redirect_to root_path
+      redirect_to user_path
     else
       render :edit
     end
@@ -27,6 +29,10 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:nickname, :introduction)
+  end
+
+  def set_residence
+    @residence = current_user.residence
   end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,12 @@
 class UsersController < ApplicationController
   before_action :set_residence, only: [:show, :edit, :logout]
+  before_action :authenticate_user!
 
   def show
-    redirect_to root_path unless @residence
+    unless @residence
+      reset_session
+      redirect_to root_path, alert: "error: ユーザー情報が破損しています。新しいユーザーを再登録してください" 
+    end
   end
   
   def edit

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,4 +9,7 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
+    .km-error-container
+      - if flash.alert.present?
+        .alert.alert-success= flash.alert
     = yield

--- a/app/views/users/_tn-sidebar.html.haml
+++ b/app/views/users/_tn-sidebar.html.haml
@@ -81,7 +81,7 @@
     %li.list
       メール/パスワード
       =fa_icon 'chevron-right', class: 'icon'
-  =link_to "/residences/#{current_user.id}/edit", class: 'tnbox' do
+  =link_to "/residences/#{@residence.id}/edit", class: 'tnbox' do
     %li.list
       本人情報
       =fa_icon 'chevron-right', class: 'icon'

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -15,7 +15,7 @@
         = f.text_field :nickname, placeholder: 'noname', autofocus: true
       .tncontents__edit__textbox
         = f.text_area :introduction, size: "75x10", placeholder: '例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪'
-        = f.submit "変更する", class: 'edit-btn tncontents__edit__textbox--btn'
+        = f.submit "変更する", class: 'tncontents__edit__textbox--btn'
 =render 'shared/top-footerimg'
 .footer
   =render 'shared/top-footer'


### PR DESCRIPTION
# What
本人情報確認ページへのリンクがユーザーの登録情報によってはエラーが出てしまう件の修正
# Why
ユーザーページのサイドバーのリンクの指定の仕方がuserのidとresidenceのidが一致している場合のみの指定方法であったため