### PR TITLE
新規登録画面のビュー関係の修正

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -45,14 +45,13 @@ class SignupController < ApplicationController
     )
 
     render 'signup/step1' unless @user.valid?
-    unless verify_recaptcha(model: @user)
-      'signup/step1'
+    unless verify_recaptcha
+      render 'signup/step1'
     end
   end
 
   def step2
     @user = User.new
-
   end
 
   def save_step2

--- a/app/views/shared/_km-header.html.haml
+++ b/app/views/shared/_km-header.html.haml
@@ -1,1 +1,2 @@
-= image_tag src="//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1248199994",class: "km-header__image"
+=link_to root_path do
+  = image_tag src="//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1248199994",class: "km-header__image"


### PR DESCRIPTION
# What
signupページのヘッダーロゴにroot_pathへのlinkを追加、recaptchの検証時のrenderがおかしい部分の修正
# Why
新規登録画面の利便性向上のため