### PR TITLE
二重バリデーション の修正

### DIFF
--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -44,8 +44,8 @@ class SignupController < ApplicationController
       birth_day: session[:birth_day]
     )
 
-    render 'signup/step1' unless @user.valid?
-    unless verify_recaptcha
+    
+    unless verify_recaptcha && @user.valid?
       render 'signup/step1'
     end
   end


### PR DESCRIPTION
# What
新規登録時recaptchaと通常バリデーション で二重のバリデーション がかかり、エラーになる問題を解消
# Why
recaptchaと通常バリデーションに引っかかると二重にrender処理をし、エラーを起こすため